### PR TITLE
Report version manually

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -37,7 +37,7 @@ func (frc *Client) VerifyCaptchaResponse(ctx context.Context, captchaResponse st
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Api-Key", frc.APIKey)
-	req.Header.Set("X-Frc-Sdk", fmt.Sprintf("friendly-captcha-go-sdk@%s", Version()))
+	req.Header.Set("X-Frc-Sdk", fmt.Sprintf("friendly-captcha-go-sdk@%s", Version))
 
 	resp, err := frc.HTTPClient.Do(req)
 	if err != nil {

--- a/version.go
+++ b/version.go
@@ -1,12 +1,3 @@
 package friendlycaptcha
 
-import (
-	"runtime/debug"
-)
-
-func Version() string {
-	if bi, ok := debug.ReadBuildInfo(); ok {
-		return bi.Main.Version
-	}
-	return "unknown"
-}
+var Version = "0.2.3"


### PR DESCRIPTION
Reporting the buildinfo module version didn't work so we'll have to change it manually before releasing.